### PR TITLE
PMMP-3.9.0: Replace use of "Entity" packets with "Actor" [Target Branch dev/3.1]

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: Texter
 prefix: Texter
 main: tokyo\pmmp\Texter\Core
 version: 3.1.0
-api: 3.0.0 # pmmp/PocketMine-MP
+api: 3.9.0 # pmmp/PocketMine-MP
 softdepend:
   - DEVirion
 author: yuko_fuyutsuki

--- a/src/tokyo/pmmp/Texter/text/FloatingText.php
+++ b/src/tokyo/pmmp/Texter/text/FloatingText.php
@@ -33,8 +33,8 @@ use pocketmine\level\Level;
 use pocketmine\level\Position;
 use pocketmine\network\mcpe\protocol\AddPlayerPacket;
 use pocketmine\network\mcpe\protocol\DataPacket;
-use pocketmine\network\mcpe\protocol\MoveEntityAbsolutePacket;
-use pocketmine\network\mcpe\protocol\RemoveEntityPacket;
+use pocketmine\network\mcpe\protocol\MoveActorAbsolutePacket;
+use pocketmine\network\mcpe\protocol\RemoveActorPacket;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 use pocketmine\utils\UUID;
@@ -182,7 +182,7 @@ class FloatingText extends Position implements Text {
         break;
 
       case Text::SEND_TYPE_MOVE:
-        $pk = new MoveEntityAbsolutePacket;
+        $pk = new MoveActorAbsolutePacket;
         $pk->entityRuntimeId = $this->eid;
         $pk->position = $this;
         $pk->xRot = 0;
@@ -191,7 +191,7 @@ class FloatingText extends Position implements Text {
         break;
 
       case Text::SEND_TYPE_REMOVE:
-        $pk = new RemoveEntityPacket;
+        $pk = new RemoveActorPacket;
         $pk->entityUniqueId = $this->eid;
         break;
 


### PR DESCRIPTION
This provides compatibility with PocketMine-MP 3.9.0 by updating the use of MoveEntityAbsolutePacket and RemoveEntityPacket to their "Actor" equivalents.  Target API is also update.