### PR TITLE
Follow pmmp changes forced by ItemStack

### DIFF
--- a/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText.php
+++ b/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText.php
@@ -19,6 +19,7 @@ use pocketmine\network\mcpe\protocol\DataPacket;
 use pocketmine\network\mcpe\protocol\PlayerListPacket;
 use pocketmine\network\mcpe\protocol\RemoveActorPacket;
 use pocketmine\network\mcpe\protocol\SetActorDataPacket;
+use pocketmine\network\mcpe\protocol\types\inventory\ItemStackWrapper;
 use pocketmine\network\mcpe\protocol\types\PlayerListEntry;
 use pocketmine\network\mcpe\protocol\types\SkinAdapterSingleton;
 use pocketmine\Player;
@@ -128,7 +129,7 @@ class FloatingText implements Sendable {
 				$pk->entityRuntimeId = $this->entityRuntimeId;
 				$pk->entityUniqueId = $this->entityRuntimeId;
 				$pk->position = $this->position;
-				$pk->item = Item::get(ItemIds::AIR);
+				$pk->item = ItemStackWrapper::legacy(Item::get(ItemIds::AIR));
 				$pk->metadata = [
 					Entity::DATA_FLAGS => [
 						Entity::DATA_TYPE_LONG, 1 << Entity::DATA_FLAG_IMMOBILE


### PR DESCRIPTION
> I use Google Translate.
## overview
This PR fixes an error caused by a specification change in the AddPlayerPacket. (ItemStackWrapper...?)

https://github.com/pmmp/PocketMine-MP/commit/c9b83d72761b36034f5c2d2e8c1668ba6c55c08c#diff-7ecd44f03d84b4996c9a59d17a92c44e1938f6da34f0420148f40c0993e6bb52L107
## Steps to reproduce the PR
```
1. Copy Texter to the plugins folder and start the server.
2. Log in to the server and use "/txt add" to add the floating characters.
```
## environment
```
Texter: dev/4.0
PocketMine-MP: 3.19.0
php: 7.4.10
os: windows
```
## error
```
Error: "Call to undefined method pocketmine\item\ItemBlock::write()" (EXCEPTION) in "pmsrc/src/pocketmine/network/mcpe/protocol/AddPlayerPacket" at line 132
#0 pmsrc/src/pocketmine/network/mcpe/protocol/DataPacket(127): pocketmine\network\mcpe\protocol\AddPlayerPacket->encodePayload()
#1 pmsrc/src/pocketmine/network/mcpe/RakLibInterface(244): pocketmine\network\mcpe\protocol\DataPacket->encode()
#2 pmsrc/src/pocketmine/Player(3359): pocketmine\network\mcpe\RakLibInterface->putPacket(object pocketmine\Player, object pocketmine\network\mcpe\protocol\AddPlayerPacket, boolean , boolean )
#3 pmsrc/src/pocketmine/Player(3376): pocketmine\Player->sendDataPacket(object pocketmine\network\mcpe\protocol\AddPlayerPacket, boolean , boolean )
#4 plugins/Texter_dev-175/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText(187): pocketmine\Player->dataPacket(object pocketmine\network\mcpe\protocol\AddPlayerPacket)
#5 plugins/Texter_dev-175/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText(193): jp\mcbe\fuyutsuki\Texter\text\FloatingText->sendToPlayer(object pocketmine\Player, object jp\mcbe\fuyutsuki\Texter\text\SendType)
#6 plugins/Texter_dev-175/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText(198): jp\mcbe\fuyutsuki\Texter\text\FloatingText->sendToPlayers(array[1], object jp\mcbe\fuyutsuki\Texter\text\SendType)
#7 plugins/Texter_dev-175/src/jp/mcbe/fuyutsuki/Texter/text/FloatingTextCluster(116): jp\mcbe\fuyutsuki\Texter\text\FloatingText->sendToLevel(object pocketmine\level\Level, object jp\mcbe\fuyutsuki\Texter\text\SendType)
#8 plugins/Texter_dev-175/src/jp/mcbe/fuyutsuki/Texter/command/form/AddFloatingTextForm(132): jp\mcbe\fuyutsuki\Texter\text\FloatingTextCluster->sendToLevel(object pocketmine\level\Level, object jp\mcbe\fuyutsuki\Texter\text\SendType)
#9 pmsrc/src/pocketmine/Player(3664): jp\mcbe\fuyutsuki\Texter\command\form\AddFloatingTextForm->handleResponse(object pocketmine\Player, array[11])
#10 pmsrc/src/pocketmine/network/mcpe/PlayerNetworkSessionAdapter(259): pocketmine\Player->onFormSubmit(integer 12, array[11])
```