### PR TITLE
Update floating text packet to floating block

### DIFF
--- a/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText.php
+++ b/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText.php
@@ -11,20 +11,13 @@ use jp\mcbe\fuyutsuki\Texter\util\dependencies\Mineflow;
 use JsonException;
 use pocketmine\block\VanillaBlocks;
 use pocketmine\entity\Entity;
-use pocketmine\entity\Skin;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\convert\RuntimeBlockMapping;
-use pocketmine\network\mcpe\convert\SkinAdapterSingleton;
 use pocketmine\network\mcpe\protocol\AddActorPacket;
-use pocketmine\network\mcpe\protocol\AddPlayerPacket;
 use pocketmine\network\mcpe\protocol\ClientboundPacket;
 use pocketmine\network\mcpe\protocol\MoveActorAbsolutePacket;
-use pocketmine\network\mcpe\protocol\PlayerListPacket;
 use pocketmine\network\mcpe\protocol\RemoveActorPacket;
 use pocketmine\network\mcpe\protocol\SetActorDataPacket;
-use pocketmine\network\mcpe\protocol\types\AbilitiesData;
-use pocketmine\network\mcpe\protocol\types\command\CommandPermissions;
-use pocketmine\network\mcpe\protocol\types\DeviceOS;
 use pocketmine\network\mcpe\protocol\types\entity\ByteMetadataProperty;
 use pocketmine\network\mcpe\protocol\types\entity\EntityIds;
 use pocketmine\network\mcpe\protocol\types\entity\EntityMetadataFlags;
@@ -34,15 +27,8 @@ use pocketmine\network\mcpe\protocol\types\entity\IntMetadataProperty;
 use pocketmine\network\mcpe\protocol\types\entity\LongMetadataProperty;
 use pocketmine\network\mcpe\protocol\types\entity\PropertySyncData;
 use pocketmine\network\mcpe\protocol\types\entity\StringMetadataProperty;
-use pocketmine\network\mcpe\protocol\types\inventory\ItemStack;
-use pocketmine\network\mcpe\protocol\types\inventory\ItemStackWrapper;
-use pocketmine\network\mcpe\protocol\types\PlayerListEntry;
-use pocketmine\network\mcpe\protocol\types\PlayerPermissions;
-use pocketmine\network\mcpe\protocol\UpdateAbilitiesPacket;
-use pocketmine\player\GameMode;
 use pocketmine\player\Player;
 use pocketmine\world\World;
-use Ramsey\Uuid\Uuid;
 
 class FloatingText implements Sendable {
 


### PR DESCRIPTION
Ima be honest, ive never used this plugin just happen to come across it. Its currently using an outdated method of creating floating text with packets. Pocketmine had a update awhile back changing from PlayerPackets to ActorPackets with floating block entities. (Details [https://github.com/pmmp/PocketMine-MP/pull/4714](here))

Feel free to deny my request, figured I would try to update. 