### PR TITLE
Add support for PMMP 5.1.x

### DIFF
--- a/.github/changelogs/4.x/en_us.md
+++ b/.github/changelogs/4.x/en_us.md
@@ -2,6 +2,12 @@
 
 ## 4.1.x
 
+### 4.1.11
+
+#### :arrow_heading_up: follow PMMP changes
+
+- Added support for PMMP 5.1.x (Minecraft 1.20.0~)
+
 ### 4.1.10
 
 #### :arrow_heading_up: follow PMMP changes

--- a/.github/changelogs/4.x/ja_jp.md
+++ b/.github/changelogs/4.x/ja_jp.md
@@ -2,6 +2,12 @@
 
 ## 4.1.x
 
+### 4.1.11
+
+#### :arrow_heading_up: PMMPの変更に追従
+
+- PMMP 5.1.x (Minecraft 1.20.0~) に対応しました
+
 ### 4.1.10
 
 #### :arrow_heading_up: PMMPの変更に追従

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 	"require-dev": {
 		"aieuo/mineflow": "^2.12.0",
 		"phpstan/phpstan": "^1.9",
-		"pocketmine/pocketmine-mp": "^5.0"
+		"pocketmine/pocketmine-mp": "^5"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 	"require-dev": {
 		"aieuo/mineflow": "^2.12.0",
 		"phpstan/phpstan": "^1.9",
-		"pocketmine/pocketmine-mp": "^4.14"
+		"pocketmine/pocketmine-mp": "^5.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,8 +1,8 @@
 name: Texter
 prefix: Texter
 main: jp\mcbe\fuyutsuki\Texter\Main
-version: 4.1.10
-api: 4.20.0
+version: 4.1.11
+api: 5.1.2
 softdepend:
   # aieuo/Mineflow
   - Mineflow # >= 2.0

--- a/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText.php
+++ b/src/jp/mcbe/fuyutsuki/Texter/text/FloatingText.php
@@ -12,7 +12,7 @@ use JsonException;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Skin;
 use pocketmine\math\Vector3;
-use pocketmine\network\mcpe\convert\SkinAdapterSingleton;
+use pocketmine\network\mcpe\convert\TypeConverter;
 use pocketmine\network\mcpe\protocol\AddPlayerPacket;
 use pocketmine\network\mcpe\protocol\ClientboundPacket;
 use pocketmine\network\mcpe\protocol\MoveActorAbsolutePacket;
@@ -116,7 +116,7 @@ class FloatingText implements Sendable {
 						$uuid,
 						$this->actorRuntimeId,
 						"",
-						SkinAdapterSingleton::get()->toSkinData(new Skin(
+						TypeConverter::getInstance()->getSkinAdapter()->toSkinData(new Skin(
 							"Standard_Custom",
 							str_repeat("\x00", 8192),
 							"",


### PR DESCRIPTION
This PR adds support for PMMP 5.1.x. Older versions like PMMP 4.20.x are no longer supported by this update.